### PR TITLE
Workspace Resource: print table with the alias field

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -8,6 +8,9 @@ ignore:
 resources:
   Workspace:
     fields:
+      alias:
+        print:
+          name: ALIAS
       Tags:
         compare:
           is_ignored: True

--- a/apis/v1alpha1/workspace.go
+++ b/apis/v1alpha1/workspace.go
@@ -53,6 +53,7 @@ type WorkspaceStatus struct {
 // Workspace is the Schema for the Workspaces API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ALIAS",type=string,priority=0,JSONPath=`.spec.alias`
 type Workspace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/prometheusservice.services.k8s.aws_workspaces.yaml
+++ b/config/crd/bases/prometheusservice.services.k8s.aws_workspaces.yaml
@@ -16,7 +16,11 @@ spec:
     singular: workspace
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.alias
+      name: ALIAS
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Workspace is the Schema for the Workspaces API

--- a/generator.yaml
+++ b/generator.yaml
@@ -8,6 +8,9 @@ ignore:
 resources:
   Workspace:
     fields:
+      alias:
+        print:
+          name: ALIAS
       Tags:
         compare:
           is_ignored: True

--- a/helm/crds/prometheusservice.services.k8s.aws_workspaces.yaml
+++ b/helm/crds/prometheusservice.services.k8s.aws_workspaces.yaml
@@ -16,7 +16,11 @@ spec:
     singular: workspace
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.alias
+      name: ALIAS
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Workspace is the Schema for the Workspaces API


### PR DESCRIPTION
Signed-off-by: Ilan <igofman99@gmail.com>

Description of changes:

When using `kubectl get workspaces`, print the table with the workspace alias.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
