### PR TITLE
Fix generator.yaml print field

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -29,7 +29,9 @@ resources:
       Name:
         is_immutable: true
       WorkspaceID:
-        is_immutable: true      
+        is_immutable: true
+        print:
+          name: WORKSPACE-ID      
       Tags:
         compare:
           is_ignored: True


### PR DESCRIPTION
Signed-off-by: Ilan <igofman99@gmail.com>

Issue #, if available:

Description of changes:

In my previous PR, I made the change to add the workspaceID to the print table for the `RuleGroupsNamespace` resource. All the changes were part of that [PR](https://github.com/aws-controllers-k8s/prometheusservice-controller/pull/7). However, I made the mistake of only commiting the changes for one the generator.yaml files instead of both. So this fix is just adding that change. The generated code part of the previous PR already includes this change. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
