### PR TITLE
Release artifacts for v0.0.2 for Prometheus Service (AMP) Controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-08-03T21:27:05Z"
+  build_date: "2022-08-11T19:40:37Z"
   build_hash: 87477ae8ca8ac6ddb8c565bbd910cc7e30f55ed0
   go_version: go1.18.3
   version: v0.19.3-dirty
-api_directory_checksum: 57b3efac72bde4af8b7f35a3d6769314bb1e7d7c
+api_directory_checksum: 2ed2eed46f763f970340c40e89f51f9d994c03c5
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 3342e92d1f649846eb0b4ccca193c91674dbded6
+  file_checksum: 6361915f762be4cc6d69493d2919b3bb4d9ebef4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/prometheusservice-controller
-  newTag: v0.0.1
+  newTag: v0.0.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: prometheusservice-chart
 description: A Helm chart for the ACK service controller for Amazon Managed Service for Prometheus (AMP)
-version: v0.0.1
-appVersion: v0.0.1
+version: v0.0.2
+appVersion: v0.0.2
 home: https://github.com/aws-controllers-k8s/prometheusservice-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/prometheusservice-controller:v0.0.1".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/prometheusservice-controller:v0.0.2".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/prometheusservice-controller
-  tag: v0.0.1
+  tag: v0.0.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Signed-off-by: Ilan <igofman99@gmail.com>

Issue #, if available: [1323](https://github.com/aws-controllers-k8s/community/issues/1323)

Description of changes: Generate the release after adding the `RuleGroupsNamespace` resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
