### PR TITLE
remove dev preview from olm file in preparation for GA

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -18,7 +18,7 @@ description: |-
 
 
   This controller is a component of the [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s)
-  project. This project is currently in **developer preview**.
+  project.
 
 
   **Pre-Installation Steps**


### PR DESCRIPTION
Issue #, if available:
NA

Description of changes:
Removing the dev preview verbiage from the OLM config file in preparation for this controller to go GA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>