### PR TITLE
Upgrading runtime and code-generator to v0.25.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-03-07T21:22:03Z"
-  build_hash: 910a8e0744a99c5c87d8c1615926985215a60d8c
-  go_version: go1.19
-  version: v0.24.3
+  build_date: "2023-04-03T16:44:00Z"
+  build_hash: a6ae2078e57187b2daf47978bc07bd67072d2cba
+  go_version: go1.20.1
+  version: v0.25.0-1-ga6ae207
 api_directory_checksum: 6b007780b2fd5cfe06509e48011e902a587bfb15
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 1f7b902ad649743284c14a4c81c8f017e85c2c1c
+  file_checksum: 95bfb993c4e69381bdb96a18740191d226077217
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -91,4 +91,5 @@ resources:
     exceptions:
       terminal_codes:
         - ValidationException
-model_name: amp 
+sdk_names:
+  model_name: amp 

--- a/generator.yaml
+++ b/generator.yaml
@@ -91,4 +91,5 @@ resources:
     exceptions:
       terminal_codes:
         - ValidationException
-model_name: amp 
+sdk_names:
+  model_name: amp 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/prometheusservice-controller
 go 1.19
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.24.1
+	github.com/aws-controllers-k8s/runtime v0.25.0
 	github.com/aws/aws-sdk-go v1.44.93
 	github.com/go-logr/logr v1.2.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/aws-controllers-k8s/runtime v0.24.1 h1:vmOWKlo4oPtPxeofRnd/dA49WR5VZSqSxHiSiNTiknY=
-github.com/aws-controllers-k8s/runtime v0.24.1/go.mod h1:jizDzKikL09cueIuA9ZxoZ+4pfn5U7oKW5s/ZAqOA6E=
+github.com/aws-controllers-k8s/runtime v0.25.0 h1:6SYa8qmbw+Yil5/LodF7LmIGxBhpjz4QEIvNjpeRuoc=
+github.com/aws-controllers-k8s/runtime v0.25.0/go.mod h1:jizDzKikL09cueIuA9ZxoZ+4pfn5U7oKW5s/ZAqOA6E=
 github.com/aws/aws-sdk-go v1.44.93 h1:hAgd9fuaptBatSft27/5eBMdcA8+cIMqo96/tZ6rKl8=
 github.com/aws/aws-sdk-go v1.44.93/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/pkg/resource/alert_manager_definition/descriptor.go
+++ b/pkg/resource/alert_manager_definition/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/rule_groups_namespace/descriptor.go
+++ b/pkg/resource/rule_groups_namespace/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/workspace/descriptor.go
+++ b/pkg/resource/workspace/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in


### PR DESCRIPTION
Issue #, if available: 
- https://github.com/aws-controllers-k8s/community/issues/1750

Description of changes:
- Update runtime version to v0.25.0
- Update code-generator version to v0.25.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
