### PR TITLE
Update IAM policy to include required CloudWatch Logs permissions

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "aps:*",
+                "logs:CreateLogDelivery",
+                "logs:DescribeLogGroups",
+                "logs:DescribeResourcePolicies",
+                "logs:PutResourcePolicy"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/config/iam/recommended-policy-arn
+++ b/config/iam/recommended-policy-arn
@@ -1,1 +1,0 @@
-arn:aws:iam::aws:policy/AmazonPrometheusConsoleFullAccess


### PR DESCRIPTION
Issue #, if available
https://github.com/aws-controllers-k8s/community/issues/1822

Description of changes:
* Changes the file name from `recommended-policy-arn` -> `recommended-inline-policy`
* Instead of the named Policy `AmazonPrometheusConsoleFullAccess` it's replaced with `aps:*`
* Adds:
  * `logs:CreateLogDelivery`
  * `logs:DescribeLogGroups`
  * `logs:DescribeResourcePolicies`
  * `logs:PutResourcePolicy`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
