### PR TITLE
Prefix e2e test log group with `/aws/vendedlogs/` to avoid hitting CW log resource policy limit

### DIFF
--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -29,10 +29,10 @@ def service_bootstrap() -> Resources:
             name_prefix="ack-prometheus-test-topic"
         ),
         LoggingConfigurationLogGroup1 = LogGroup(
-            name_prefix="ack-prometheus-test-log-group1"
+            name_prefix="/aws/vendedlogs/aps/ack-prometheus-test-log-group1"
         ),
         LoggingConfigurationLogGroup2 = LogGroup(
-            name_prefix="ack-prometheus-test-log-group2"
+            name_prefix="/aws/vendedlogs/aps/ack-prometheus-test-log-group2"
         ),
     )
 


### PR DESCRIPTION

Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1973

Description of changes: See title

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
