### PR TITLE
tests: Ready condition rename for prometheusservice-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-19T16:52:52Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-25T05:55:19Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9
 api_directory_checksum: 181d33af664fd0bf2ee09e01c23cd9ca5e6493b4
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/crd/bases/prometheusservice.services.k8s.aws_alertmanagerdefinitions.yaml
+++ b/config/crd/bases/prometheusservice.services.k8s.aws_alertmanagerdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: alertmanagerdefinitions.prometheusservice.services.k8s.aws
 spec:
   group: prometheusservice.services.k8s.aws

--- a/config/crd/bases/prometheusservice.services.k8s.aws_loggingconfigurations.yaml
+++ b/config/crd/bases/prometheusservice.services.k8s.aws_loggingconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: loggingconfigurations.prometheusservice.services.k8s.aws
 spec:
   group: prometheusservice.services.k8s.aws

--- a/config/crd/bases/prometheusservice.services.k8s.aws_rulegroupsnamespaces.yaml
+++ b/config/crd/bases/prometheusservice.services.k8s.aws_rulegroupsnamespaces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: rulegroupsnamespaces.prometheusservice.services.k8s.aws
 spec:
   group: prometheusservice.services.k8s.aws

--- a/config/crd/bases/prometheusservice.services.k8s.aws_workspaces.yaml
+++ b/config/crd/bases/prometheusservice.services.k8s.aws_workspaces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: workspaces.prometheusservice.services.k8s.aws
 spec:
   group: prometheusservice.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -84,6 +82,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/prometheusservice.services.k8s.aws_alertmanagerdefinitions.yaml
+++ b/helm/crds/prometheusservice.services.k8s.aws_alertmanagerdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: alertmanagerdefinitions.prometheusservice.services.k8s.aws
 spec:
   group: prometheusservice.services.k8s.aws

--- a/helm/crds/prometheusservice.services.k8s.aws_loggingconfigurations.yaml
+++ b/helm/crds/prometheusservice.services.k8s.aws_loggingconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: loggingconfigurations.prometheusservice.services.k8s.aws
 spec:
   group: prometheusservice.services.k8s.aws

--- a/helm/crds/prometheusservice.services.k8s.aws_rulegroupsnamespaces.yaml
+++ b/helm/crds/prometheusservice.services.k8s.aws_rulegroupsnamespaces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: rulegroupsnamespaces.prometheusservice.services.k8s.aws
 spec:
   group: prometheusservice.services.k8s.aws

--- a/helm/crds/prometheusservice.services.k8s.aws_workspaces.yaml
+++ b/helm/crds/prometheusservice.services.k8s.aws_workspaces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: workspaces.prometheusservice.services.k8s.aws
 spec:
   group: prometheusservice.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/alert_manager_definition/references.go
+++ b/pkg/resource/alert_manager_definition/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -135,8 +136,9 @@ func getReferencedResourceState_Workspace(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Workspace",
 				namespace, name)
@@ -147,14 +149,14 @@ func getReferencedResourceState_Workspace(
 			"Workspace",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Workspace",
 			namespace, name)

--- a/pkg/resource/logging_configuration/references.go
+++ b/pkg/resource/logging_configuration/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -135,8 +136,9 @@ func getReferencedResourceState_Workspace(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Workspace",
 				namespace, name)
@@ -147,14 +149,14 @@ func getReferencedResourceState_Workspace(
 			"Workspace",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Workspace",
 			namespace, name)

--- a/pkg/resource/rule_groups_namespace/references.go
+++ b/pkg/resource/rule_groups_namespace/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -135,8 +136,9 @@ func getReferencedResourceState_Workspace(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Workspace",
 				namespace, name)
@@ -147,14 +149,14 @@ func getReferencedResourceState_Workspace(
 			"Workspace",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Workspace",
 			namespace, name)

--- a/test/e2e/condition.py
+++ b/test/e2e/condition.py
@@ -22,7 +22,7 @@ import pytest
 from acktest.k8s import resource as k8s
 
 CONDITION_TYPE_ADOPTED = "ACK.Adopted"
-CONDITION_TYPE_RESOURCE_SYNCED = "ACK.ResourceSynced"
+CONDITION_TYPE_READY = "Ready"
 CONDITION_TYPE_TERMINAL = "ACK.Terminal"
 CONDITION_TYPE_RECOVERABLE = "ACK.Recoverable"
 CONDITION_TYPE_ADVISORY = "ACK.Advisory"
@@ -31,11 +31,11 @@ CONDITION_TYPE_LATE_INITIALIZED = "ACK.LateInitialized"
 
 def assert_type_status(
     ref: k8s.CustomResourceReference,
-    cond_type_match: str = CONDITION_TYPE_RESOURCE_SYNCED,
+    cond_type_match: str = CONDITION_TYPE_READY,
     cond_status_match: bool = True,
 ):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource as k8s
@@ -50,7 +50,7 @@ def assert_type_status(
         k8s.wait_resource_consumed_by_controller(ref)
         condition.assert_type_status(
             ref,
-            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            condition.CONDITION_TYPE_READY,
             False)
 
     Raises:
@@ -75,7 +75,7 @@ def assert_synced_status(
     cond_status_match: bool,
 ):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource as k8s
@@ -91,15 +91,15 @@ def assert_synced_status(
         condition.assert_synced_status(ref, False)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a True status.
     """
-    assert_type_status(ref, CONDITION_TYPE_RESOURCE_SYNCED, cond_status_match)
+    assert_type_status(ref, CONDITION_TYPE_READY, cond_status_match)
 
 
-def assert_synced(ref: k8s.CustomResourceReference):
+def assert_ready(ref: k8s.CustomResourceReference):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource as k8s
@@ -112,18 +112,18 @@ def assert_synced(ref: k8s.CustomResourceReference):
         )
         k8s.create_custom_resource(ref, resource_data)
         k8s.wait_resource_consumed_by_controller(ref)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a True status.
     """
     return assert_synced_status(ref, True)
 
 
-def assert_not_synced(ref: k8s.CustomResourceReference):
+def assert_not_ready(ref: k8s.CustomResourceReference):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is False.
+    Ready and that the Status of this condition is False.
 
     Usage:
         from acktest.k8s import resource as k8s
@@ -136,10 +136,10 @@ def assert_not_synced(ref: k8s.CustomResourceReference):
         )
         k8s.create_custom_resource(ref, resource_data)
         k8s.wait_resource_consumed_by_controller(ref)
-        condition.assert_not_synced(ref)
+        condition.assert_not_ready(ref)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a False status.
     """
     return assert_synced_status(ref, False)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5a09bbdb961ea14a65b15b63769134125023ac61
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428

--- a/test/e2e/tests/test_alert_manager_definition.py
+++ b/test/e2e/tests/test_alert_manager_definition.py
@@ -61,7 +61,7 @@ def workspace_resource():
         assert workspace_resource is not None
         assert k8s.get_resource_exists(workspace_ref)
 
-        assert k8s.wait_on_condition(workspace_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(workspace_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
         assert 'workspaceID' in workspace_resource['status']
 
         yield (workspace_ref, workspace_resource)
@@ -131,9 +131,9 @@ class TestAlertManagerDefinition:
         assert am_resource['spec']['workspaceID'] == workspace_id
         assert 'configuration' in am_resource['spec']
         assert am_resource['spec']['configuration'] == configuration_str
-        condition.assert_not_synced(am_ref)
+        condition.assert_not_ready(am_ref)
 
-        assert k8s.wait_on_condition(am_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(am_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After the resource is synced, assert that alert manager definition is active
         latest = self.get_alert_manager_definition(prometheusservice_client, workspace_id)
@@ -152,7 +152,7 @@ class TestAlertManagerDefinition:
         assert 'status' in am_resource
         assert 'statusCode' in am_resource['status']
         assert am_resource['status']['statusCode'] == 'ACTIVE'
-        condition.assert_synced(am_ref)
+        condition.assert_ready(am_ref)
 
         # Now, we update the resource with a new INVALID configuration. 
         # This kind of invalid configuration doesn't result in a validationexcpetion from the http request. 
@@ -184,7 +184,7 @@ class TestAlertManagerDefinition:
         assert 'statusCode' in am_resource['status']
         assert am_resource['status']['statusCode'] == 'UPDATING'
 
-        assert k8s.wait_on_condition(am_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(am_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After the resource is synced, assert that alert manager is active
         latest = self.get_alert_manager_definition(prometheusservice_client, workspace_id)
@@ -201,7 +201,7 @@ class TestAlertManagerDefinition:
         assert 'status' in am_resource
         assert 'statusCode' in am_resource['status']
         assert am_resource['status']['statusCode'] == 'ACTIVE'
-        condition.assert_synced(am_ref)
+        condition.assert_ready(am_ref)
 
 
         # Delete the alert manager definition
@@ -278,8 +278,8 @@ class TestAlertManagerDefinition:
         assert 'configuration' in am_resource['spec']
         assert am_resource['spec']['configuration'] == configuration_str
 
-        condition.assert_not_synced(am_ref)
-        assert k8s.wait_on_condition(am_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        condition.assert_not_ready(am_ref)
+        assert k8s.wait_on_condition(am_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After the resource is synced, assert that workspace is active
         latest = self.get_alert_manager_definition(prometheusservice_client, workspace_id)
@@ -298,7 +298,7 @@ class TestAlertManagerDefinition:
         assert 'status' in am_resource
         assert 'statusCode' in am_resource['status']
         assert am_resource['status']['statusCode'] == 'CREATION_FAILED'
-        condition.assert_synced(am_ref)
+        condition.assert_ready(am_ref)
 
     
         # Next, we want to update it to a valid configuration.
@@ -320,7 +320,7 @@ class TestAlertManagerDefinition:
         res= k8s.patch_custom_resource(am_ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        assert k8s.wait_on_condition(am_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(am_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After the resource is synced, assert that workspace is active
         latest = self.get_alert_manager_definition(prometheusservice_client, workspace_id)
@@ -396,9 +396,9 @@ class TestAlertManagerDefinition:
         assert am_resource['spec'] is not None
         assert 'workspaceID' in am_resource['spec']
         assert am_resource['spec']['workspaceID'] == workspace_id
-        condition.assert_not_synced(am_ref)
+        condition.assert_not_ready(am_ref)
 
-        assert k8s.wait_on_condition(am_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(am_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After the resource is synced, assert that workspace is active
         latest = self.get_alert_manager_definition(prometheusservice_client, workspace_id)
@@ -417,7 +417,7 @@ class TestAlertManagerDefinition:
         assert 'status' in am_resource
         assert 'statusCode' in am_resource['status']
         assert am_resource['status']['statusCode'] == 'ACTIVE'
-        condition.assert_synced(am_ref)
+        condition.assert_ready(am_ref)
 
 
         # To make the update, first load the invalid configuration
@@ -439,7 +439,7 @@ class TestAlertManagerDefinition:
         k8s.patch_custom_resource(am_ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        assert k8s.wait_on_condition(am_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(am_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         latest = self.get_alert_manager_definition(prometheusservice_client, workspace_id)
         assert latest is not None
@@ -457,7 +457,7 @@ class TestAlertManagerDefinition:
 
         k8s.patch_custom_resource(am_ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(am_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(am_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After the resource is synced, assert that information matches
         latest = self.get_alert_manager_definition(prometheusservice_client, workspace_id)
@@ -525,7 +525,7 @@ class TestAlertManagerDefinition:
         assert am_resource['spec'] is not None
         assert 'workspaceID' in am_resource['spec']
         assert am_resource['spec']['workspaceID'] == workspace_id
-        condition.assert_not_synced(am_ref_1)
+        condition.assert_not_ready(am_ref_1)
 
         # Create the second definition (Same workspace ID)
         replacements['ALERT_MANAGER_DEFINITION_NAME'] = resource_name + '-new'
@@ -546,11 +546,11 @@ class TestAlertManagerDefinition:
         
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(am_ref_1)
+        condition.assert_ready(am_ref_1)
 
         # The second resource should have a terminal error
         condition.assert_type_status(am_ref_2, condition.CONDITION_TYPE_TERMINAL, True)
-        condition.assert_not_synced(am_ref_2)
+        condition.assert_not_ready(am_ref_2)
 
         _, deleted = k8s.delete_custom_resource(am_ref_1)
         assert deleted

--- a/test/e2e/tests/test_logging_configuration.py
+++ b/test/e2e/tests/test_logging_configuration.py
@@ -58,7 +58,7 @@ def workspace_resource():
         assert workspace_resource is not None
         assert k8s.get_resource_exists(workspace_ref)
 
-        assert k8s.wait_on_condition(workspace_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(workspace_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
         assert 'workspaceID' in workspace_resource['status']
 
         yield (workspace_ref, workspace_resource)
@@ -117,10 +117,10 @@ class TestLoggingConfiguration:
         assert lc_resource['status']['statusCode'] == 'CREATING'
         assert lc_resource['spec']['workspaceID'] == workspace_id
         assert lc_resource['spec']['logGroupARN'] == log_group_arn
-        condition.assert_not_synced(lc_ref)
+        condition.assert_not_ready(lc_ref)
 
         # Wait for the resource to get synced
-        assert k8s.wait_on_condition(lc_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(lc_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After the resource is synced, assert that workspace is active
         latest = self.get_logging_configuration(prometheusservice_client, lc_resource['spec']['workspaceID'])
@@ -141,7 +141,7 @@ class TestLoggingConfiguration:
         assert 'status' in lc_resource
         assert 'statusCode' in lc_resource['status']
         assert lc_resource['status']['statusCode'] == 'ACTIVE'
-        condition.assert_synced(lc_ref)
+        condition.assert_ready(lc_ref)
 
         # Update the log group ARN
         new_log_group_arn = get_bootstrap_resources().LoggingConfigurationLogGroup2.arn
@@ -152,7 +152,7 @@ class TestLoggingConfiguration:
         res= k8s.patch_custom_resource(lc_ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
         # wait for the resource to get synced after the patch
-        assert k8s.wait_on_condition(lc_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(lc_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
         latest = self.get_logging_configuration(prometheusservice_client, lc_resource['spec']['workspaceID'])
         assert latest is not None
         assert latest['loggingConfiguration']['logGroupArn'] == new_log_group_arn

--- a/test/e2e/tests/test_workspace.py
+++ b/test/e2e/tests/test_workspace.py
@@ -77,10 +77,10 @@ class TestWorkspace:
         assert 'statusCode' in workspace_resource['status']['status']
         assert workspace_resource['status']['status']['statusCode'] == 'CREATING'
         assert 'workspaceID' in workspace_resource['status']
-        condition.assert_not_synced(workspace_ref)
+        condition.assert_not_ready(workspace_ref)
 
         # Wait for the resource to get synced
-        assert k8s.wait_on_condition(workspace_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(workspace_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After the resource is synced, assert that workspace is active
         latest = self.get_workspace(prometheusservice_client, workspace_resource['status']['workspaceID'])
@@ -100,7 +100,7 @@ class TestWorkspace:
         assert 'status' in workspace_resource['status']
         assert 'statusCode' in workspace_resource['status']['status']
         assert workspace_resource['status']['status']['statusCode'] == 'ACTIVE'
-        condition.assert_synced(workspace_ref)
+        condition.assert_ready(workspace_ref)
 
         # Next, we verify that the AMP server-side workspace values are the same as
         # defined in the CR. Afterwards, we modify the spec and verify that the AMP 
@@ -133,7 +133,7 @@ class TestWorkspace:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # wait for the resource to get synced after the patch
-        assert k8s.wait_on_condition(workspace_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(workspace_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
         latest = self.get_workspace(prometheusservice_client, workspace_resource['status']['workspaceID'])
         assert latest is not None
         assert latest['workspace']['alias'] == new_alias
@@ -156,7 +156,7 @@ class TestWorkspace:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # wait for the resource to get synced after the patch
-        assert k8s.wait_on_condition(workspace_ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+        assert k8s.wait_on_condition(workspace_ref, "Ready", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
 
         # After resource is synced again, assert that patches are reflected in the AWS resource
         latest = self.get_workspace(prometheusservice_client, workspace_resource['status']['workspaceID'])


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._